### PR TITLE
Add healthcheck url support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Refer [Github releases](https://github.com/Codigami/gohaqd/releases) for changelog
+
 ## v2.0 (August 23, 2017)
 
   * Use config file for multiple queue configuration ([#5](https://github.com/Codigami/gohaqd/pull/5), [@ApsOps](https://github.com/ApsOps))

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ It pulls data off a queue, inserts it into the message body, and sends an HTTP P
 ```
 ## Flags:
 ```
-      --aws-region string     AWS Region for the SQS queue (default "us-east-1")
-  -c, --config string         config file (default is ./gohaqd.yaml) (default "./gohaqd.yaml")
-  -h, --help                  help for gohaqd
-      --parallel int          Number of messages to be consumed in parallel (default 1)
-  -q, --queue-name string     queue name. (Used only when --config is not set and default config doesn't exist)
-      --sqs-endpoint string   SQS Endpoint for using with fake_sqs
-  -u, --url string            HTTP endpoint. Takes the URL from the message by default. (Used only when --config is not set and default config doesn't exist)
+      --aws-region string        AWS Region for the SQS queue (default "us-east-1")
+  -c, --config string            config file path (default "./gohaqd.yaml")
+      --healthcheck-url string   HTTP endpoint for checking if consumer server is up
+  -h, --help                     help for gohaqd
+      --parallel int             Number of messages to be consumed in parallel (default 1)
+      --port int                 Port used by metrics server (default 8090)
+  -q, --queue-name string        queue name. (Used only when --config is not set and default config doesn't exist)
+      --sqs-endpoint string      SQS Endpoint for using with fake_sqs
+  -u, --url string               HTTP endpoint. Takes the URL from the message by default. (Used only when --config is not set and default config doesn't exist)
 ```
 
 ## Sample config file:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -245,9 +245,17 @@ func sendMessageToURL(msg string, queue Queue) bool {
 		}
 	}
 
-	resp, err = httpClient.Post(endpoint, "application/json", bytes.NewBuffer([]byte(msg)))
-	if err != nil {
-		log.Printf("%s: Error hitting endpoint with msg '%s'... Error: %s", queue.Name, msg, err.Error())
+	for {
+		resp, err = httpClient.Post(endpoint, "application/json", bytes.NewBuffer([]byte(msg)))
+		if err == nil {
+			break
+		}
+		if healthcheckURL != "" {
+			log.Printf("%s: Error hitting endpoint with msg '%s'... Error: %s", queue.Name, msg, err.Error())
+			break
+		}
+		log.Printf("%s: Error hitting endpoint with msg '%s', retrying after 1 second... Error: %s", queue.Name, msg, err.Error())
+		time.Sleep(time.Second)
 	}
 	defer resp.Body.Close()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,7 @@ type Config struct {
 var cfgFile string
 var queueName string
 var url string
+var healthcheckURL string
 var awsRegion string
 var sqsEndpoint string
 var parallelRequests int
@@ -81,10 +82,11 @@ func Execute() {
 }
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "./gohaqd.yaml", "config file")
+	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "./gohaqd.yaml", "config file path")
 	RootCmd.PersistentFlags().StringVarP(&queueName, "queue-name", "q", "", "queue name. (Used only when --config is not set and default config doesn't exist)")
 	RootCmd.PersistentFlags().StringVarP(&url, "url", "u", "", "HTTP endpoint. Takes the URL from the message by default. (Used only when --config is not set and default config doesn't exist)")
 
+	RootCmd.PersistentFlags().StringVar(&healthcheckURL, "healthcheck-url", "", "HTTP endpoint for checking if consumer server is up")
 	RootCmd.PersistentFlags().StringVar(&awsRegion, "aws-region", "us-east-1", "AWS Region for the SQS queue")
 	RootCmd.PersistentFlags().StringVar(&sqsEndpoint, "sqs-endpoint", "", "SQS Endpoint for using with fake_sqs")
 	RootCmd.PersistentFlags().IntVar(&parallelRequests, "parallel", 1, "Number of messages to be consumed in parallel")
@@ -125,6 +127,22 @@ func startGohaqd(cmd *cobra.Command, args []string) {
 	}
 	sess := session.New(awsConfig)
 	svc = sqs.New(sess)
+
+	if healthcheckURL != "" {
+		var resp *http.Response
+		var err error
+
+		for {
+			resp, err = httpClient.Get(healthcheckURL)
+			if err == nil {
+				log.Println("Consumer server healthcheck successful. Starting processing.")
+				break
+			}
+			log.Printf("Consumer server healthcheck failed, retrying after 5 seconds... Error: %s", err.Error())
+			time.Sleep(5 * time.Second)
+		}
+		defer resp.Body.Close()
+	}
 
 	for _, q := range config.Queues {
 		initializeQueue(q)
@@ -227,13 +245,9 @@ func sendMessageToURL(msg string, queue Queue) bool {
 		}
 	}
 
-	for {
-		resp, err = httpClient.Post(endpoint, "application/json", bytes.NewBuffer([]byte(msg)))
-		if err == nil {
-			break
-		}
-		log.Printf("%s: Error hitting endpoint with msg '%s', retrying after 1 second... Error: %s", queue.Name, msg, err.Error())
-		time.Sleep(time.Second)
+	resp, err = httpClient.Post(endpoint, "application/json", bytes.NewBuffer([]byte(msg)))
+	if err != nil {
+		log.Printf("%s: Error hitting endpoint with msg '%s'... Error: %s", queue.Name, msg, err.Error())
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
- make sure consumer app is healthy before sending messages
- don't retry in case of server errors (let queue retry policy take care of it)